### PR TITLE
Update handling of multiple groups in recording

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -453,7 +453,8 @@ if __name__ == "__main__":
                                     logging.info(f"Aggregating {len(recording_list)} for {recording_name}")
                                     recording = recording_all
 
-                            if len(recording_list) == 1:
+                            channel_groups = recording.get_channel_groups()
+                            if len(np.unique(channel_groups)) == 1:
                                 # single shank probe
                                 recording.set_channel_groups([probe_device_name] * recording.get_num_channels())
                                 electrode_groups_metadata = [
@@ -465,7 +466,6 @@ if __name__ == "__main__":
                                     )
                                 ]
                             else:
-                                channel_groups = recording.get_channel_groups()
                                 recording.set_channel_groups([f"{probe_device_name}_group{g}" for g in channel_groups])
                                 channel_groups = np.unique(recording.get_channel_groups())
                                 electrode_groups_metadata = [


### PR DESCRIPTION
This PR makes sure that channel groups are handled the same way as the `aind-ecephys-nwb` capsule.

A mismatch result in an error when shanks are not processed in parallel: https://github.com/AllenNeuralDynamics/aind-ephys-pipeline/issues/38